### PR TITLE
Polyfill async endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ Ideas:
 -----
 
 - make it conform to [smacker](https://npmjs.com/package/smacker) in some way? Is that good with the setup we do?
-- polyfill async handler for everything until it is native?
 - versioning support (ooh interesting)
-- zod validation errors -> http error 400 in final handler -- maybe also support other validator errors?
 
 Spinoffs:
 serialize everything

--- a/example/app.js
+++ b/example/app.js
@@ -24,4 +24,14 @@ app.post('/validation', express.json(), (req, res) => {
     res.send(body);
 });
 
+app.get('/async', async (req, res) => {
+    await thisMethodErrors();
+    res.send("somehow returned without failing?? bad");
+});
+
+async function thisMethodErrors() {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    throw new Error("Task failed succesfully!");
+}
+
 app.listen(5212);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "cors": "^2.8.5",
         "dexpress-finalhandler": "^0.1.2",
         "express": "^4.18.1",
+        "express-async-handler": "^1.2.0",
         "express-prometheus-middleware": "^1.2.0",
         "helmet": "^5.1.0",
         "http-errors": "^2.0.0",
+        "methods": "^1.1.2",
         "pino-http": "^7.1.0",
         "serialize-every-error": "^0.1.1",
         "uuid": "^8.3.2"
@@ -745,6 +747,11 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
     },
     "node_modules/express-prometheus-middleware": {
       "version": "1.2.0",
@@ -3703,6 +3710,11 @@
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       }
+    },
+    "express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
     },
     "express-prometheus-middleware": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
     "cors": "^2.8.5",
     "dexpress-finalhandler": "^0.1.2",
     "express": "^4.18.1",
+    "express-async-handler": "^1.2.0",
     "express-prometheus-middleware": "^1.2.0",
     "helmet": "^5.1.0",
     "http-errors": "^2.0.0",
+    "methods": "^1.1.2",
     "pino-http": "^7.1.0",
     "serialize-every-error": "^0.1.1",
     "uuid": "^8.3.2"


### PR DESCRIPTION
Polyfills proper handling of async endpoints until the feature lands in express 5.x by attaching `express-async-handler` to all endpoints and middlewares at registration time