### PR TITLE
Validation error handling

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,4 +1,5 @@
 import express from '../index.js';
+import z from 'zod';
 
 const app = await express();
 
@@ -12,6 +13,15 @@ app.get('/error', (req, res, next) => {
     er.additional = "information";
     console.log("er", er.constructor.name, er.name);
     next(er);
+});
+
+const validationRequest = z.object({
+    message: z.string(),
+    numerically: z.number().positive().gt(5).int().optional(),
+});
+app.post('/validation', express.json(), (req, res) => {
+    const body = validationRequest.parse(req.body);
+    res.send(body);
 });
 
 app.listen(5212);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,29 @@
 {
-  "name": "dexpress",
+  "name": "dexpress-main",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "dexpress",
+      "name": "dexpress-main",
+      "version": "0.1.1",
+      "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
-        "dexpress-finalhandler": "^0.1.0",
+        "dexpress-finalhandler": "^0.1.1",
         "express": "^4.18.1",
         "express-prometheus-middleware": "^1.2.0",
         "helmet": "^5.1.0",
+        "http-errors": "^2.0.0",
         "pino-http": "^7.1.0",
         "serialize-every-error": "^0.1.1",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
         "nodemon": "^2.0.16",
-        "pino-pretty": "^8.0.0"
-      },
-      "version": "0.1.1"
+        "pino-pretty": "^8.0.0",
+        "zod": "^3.17.3"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -599,9 +603,9 @@
       }
     },
     "node_modules/dexpress-finalhandler": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dexpress-finalhandler/-/dexpress-finalhandler-0.1.0.tgz",
-      "integrity": "sha512-gvzWeHJKQA8WgkaxOwOkoVu0z97lvVbbbLiz0oUFSqglm4FN0UJlscyFMZ6BltF4wXWmMjrlFsvud0UKRqBFoA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dexpress-finalhandler/-/dexpress-finalhandler-0.1.1.tgz",
+      "integrity": "sha512-tu5OvOQ86J+HElR93jQE1W9D+4HJwumucB0XSjYRV6O2yQlPN/QKLU0l1sXUIF1sINOq1xNOLao8TODJ8D4+dA==",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -3126,6 +3130,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/zod": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -3569,9 +3582,9 @@
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
     "dexpress-finalhandler": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dexpress-finalhandler/-/dexpress-finalhandler-0.1.0.tgz",
-      "integrity": "sha512-gvzWeHJKQA8WgkaxOwOkoVu0z97lvVbbbLiz0oUFSqglm4FN0UJlscyFMZ6BltF4wXWmMjrlFsvud0UKRqBFoA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dexpress-finalhandler/-/dexpress-finalhandler-0.1.1.tgz",
+      "integrity": "sha512-tu5OvOQ86J+HElR93jQE1W9D+4HJwumucB0XSjYRV6O2yQlPN/QKLU0l1sXUIF1sINOq1xNOLao8TODJ8D4+dA==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -5500,7 +5513,12 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
+      "dev": true
     }
-  },
-  "version": "0.1.1"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
-        "dexpress-finalhandler": "^0.1.1",
+        "dexpress-finalhandler": "^0.1.2",
         "express": "^4.18.1",
         "express-prometheus-middleware": "^1.2.0",
         "helmet": "^5.1.0",
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/dexpress-finalhandler": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dexpress-finalhandler/-/dexpress-finalhandler-0.1.1.tgz",
-      "integrity": "sha512-tu5OvOQ86J+HElR93jQE1W9D+4HJwumucB0XSjYRV6O2yQlPN/QKLU0l1sXUIF1sINOq1xNOLao8TODJ8D4+dA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dexpress-finalhandler/-/dexpress-finalhandler-0.1.2.tgz",
+      "integrity": "sha512-xRiYcUxId99GK5Ade+3KHFxt/8PQX2O/PY/EMuyM3xXnOh2JufX0TS26UW984GOuoeEKgmzb+vuTL+gSJzLoKw==",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -3582,9 +3582,9 @@
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
     "dexpress-finalhandler": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dexpress-finalhandler/-/dexpress-finalhandler-0.1.1.tgz",
-      "integrity": "sha512-tu5OvOQ86J+HElR93jQE1W9D+4HJwumucB0XSjYRV6O2yQlPN/QKLU0l1sXUIF1sINOq1xNOLao8TODJ8D4+dA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dexpress-finalhandler/-/dexpress-finalhandler-0.1.2.tgz",
+      "integrity": "sha512-xRiYcUxId99GK5Ade+3KHFxt/8PQX2O/PY/EMuyM3xXnOh2JufX0TS26UW984GOuoeEKgmzb+vuTL+gSJzLoKw==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "dependencies": {
     "cors": "^2.8.5",
-    "dexpress-finalhandler": "^0.1.0",
+    "dexpress-finalhandler": "^0.1.1",
     "express": "^4.18.1",
     "express-prometheus-middleware": "^1.2.0",
     "helmet": "^5.1.0",
+    "http-errors": "^2.0.0",
     "pino-http": "^7.1.0",
     "serialize-every-error": "^0.1.1",
     "uuid": "^8.3.2"
@@ -12,7 +13,8 @@
   "type": "module",
   "devDependencies": {
     "nodemon": "^2.0.16",
-    "pino-pretty": "^8.0.0"
+    "pino-pretty": "^8.0.0",
+    "zod": "^3.17.3"
   },
   "scripts": {
     "example": "node example/app | pino-pretty"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "cors": "^2.8.5",
-    "dexpress-finalhandler": "^0.1.1",
+    "dexpress-finalhandler": "^0.1.2",
     "express": "^4.18.1",
     "express-prometheus-middleware": "^1.2.0",
     "helmet": "^5.1.0",

--- a/setUpApplicationDefaults.js
+++ b/setUpApplicationDefaults.js
@@ -65,7 +65,7 @@ export default async (app) => {
     const originalHandle = app.handle.bind(app);
     app.handle = (req, res, callback) => {
         originalHandle(req, res, callback || finalhandler(req, res, {
-            onerror: (err) => req.log.error({ err }, 'An error occurred'),
+            onservererror: (err) => req.log.error({ err }, 'An error occurred'),
             errortransform: (err) => {
                 if(err.issues && err.name === 'ZodError') {
                     return createHttpError(400, 'Invalid request', { issues: err.issues });


### PR DESCRIPTION
This is mostly an example, using `zod` as a case, for how we can transform client errors properly (and automatically) instead of having to deal with custom responses. Throw a validation error, and it is a validation error.

This may not be something that should live inside this codebase long term --- maybe it is something we should configure? or extract to a library `transform-validation-error`? --- but I think it makes sense to put it here for now (and even expand with more validation errors supported) until we know where to move it.